### PR TITLE
Avoid issue with nil value in HTTP header

### DIFF
--- a/lib/ievkit/client.rb
+++ b/lib/ievkit/client.rb
@@ -130,7 +130,7 @@ module Ievkit
     end
 
     def init_iev_version
-      { 'Accept-Version': ENV['IEV_VERSION'] }
+      { 'Accept-Version': ENV['IEV_VERSION'] ? ENV['IEV_VERSION'] : "" }
     end
   end
 end


### PR DESCRIPTION
Fix issue with `Unable to contact IEV server` in case the environment variable IEV_VERSION is not set. See also: https://github.com/ruby/ruby/commit/809d3770e69e72913358d8da5e779d0334d4c5cb
