### PR TITLE
Add environment variable to disable redis cache

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -3,3 +3,4 @@ IEV_HOST:
 IEV_PORT:
 IEV_PATH:
 iev_admin_key:
+IEV_DISABLE_CACHE:

--- a/lib/ievkit/client.rb
+++ b/lib/ievkit/client.rb
@@ -9,6 +9,7 @@ module Ievkit
       @iev_url_prefix_admin = init_iev_url_prefix_admin
       @iev_url_list_tests = init_iev_url_list_tests
       @iev_url_jobs = init_iev_url_jobs
+      @iev_disable_cache = init_iev_disable_cache
       @redis = Redis.new
     end
 
@@ -25,8 +26,8 @@ module Ievkit
       end
     end
 
-    def prepare_request(url, http_method, disable_cache = false)
-      unless disable_cache
+    def prepare_request(url, http_method)
+      unless @iev_disable_cache
         cache_key = [url, http_method.to_s].join('_')
         begin
           response_cached = @redis.cache(cache_key)
@@ -38,7 +39,7 @@ module Ievkit
       init_connection(url)
       begin
         response = @connection.send(http_method)
-        unless disable_cache
+        unless @iev_disable_cache
           cache_control = response.headers['cache-control']
           max_age = 0
           no_cache = true
@@ -181,6 +182,10 @@ module Ievkit
 
     def init_iev_version
       { 'Accept-Version': ENV['IEV_VERSION'] }
+    end
+
+    def init_iev_disable_cache
+      ENV['IEV_DISABLE_CACHE'] == 'true'
     end
   end
 end

--- a/lib/ievkit/job.rb
+++ b/lib/ievkit/job.rb
@@ -1,7 +1,6 @@
 module Ievkit
   class Job
     attr_reader :client, :response
-    attr_accessor :disable_cache
 
     def initialize(referential_id)
       @client = Ievkit::Client.new(referential_id)
@@ -38,7 +37,7 @@ module Ievkit
     protected
 
     def do_job(url, http_method)
-      @client.prepare_request(url, http_method, @disable_cache)
+      @client.prepare_request(url, http_method)
     end
 
     def importer(type, options)


### PR DESCRIPTION
Makes it possible to disable the redis cache by using an environmental variable: _IEV_DISABLE_CACHE_

For the reference, see https://github.com/afimb/ievkit_views/pull/1
